### PR TITLE
Auth-generated datatime definitions update

### DIFF
--- a/example.raml
+++ b/example.raml
@@ -45,7 +45,6 @@ securitySchemes:
 securedBy: [x_ticket_auth]
 
 /stories:
-    securedBy: [read_only_users]
     displayName: All stories
     get:
         description: Get all stories
@@ -69,7 +68,6 @@ securedBy: [x_ticket_auth]
             description: Update a particular story
 
 /users:
-    securedBy: [read_only_useritem_everyone]
     displayName: All users
     get:
         description: Get all users
@@ -111,5 +109,5 @@ securedBy: [x_ticket_auth]
                 body:
                     application/json:
                         schema: !include schemas/profile.json
-            put:
+            patch:
                 description: Update a user's profile

--- a/example.raml
+++ b/example.raml
@@ -45,6 +45,7 @@ securitySchemes:
 securedBy: [x_ticket_auth]
 
 /stories:
+    securedBy: [read_only_users]
     displayName: All stories
     get:
         description: Get all stories
@@ -68,6 +69,7 @@ securedBy: [x_ticket_auth]
             description: Update a particular story
 
 /users:
+    securedBy: [read_only_useritem_everyone]
     displayName: All users
     get:
         description: Get all users

--- a/schemas/profile.json
+++ b/schemas/profile.json
@@ -10,6 +10,14 @@
                 "primary_key": true
             }
         },
+        "created_at": {
+            "required": false,
+            "type": "datetime"
+        },
+        "updated_at": {
+            "required": false,
+            "type": "datetime"
+        },
         "address": {
             "required": false,
             "type": "unicode_text"

--- a/schemas/profile.json
+++ b/schemas/profile.json
@@ -12,7 +12,10 @@
         },
         "created_at": {
             "required": false,
-            "type": "datetime"
+            "type": "datetime",
+            "args": {
+                "default": "{{datetime.datetime.utcnow}}"
+            }
         },
         "updated_at": {
             "required": false,

--- a/schemas/profile.json
+++ b/schemas/profile.json
@@ -19,7 +19,10 @@
         },
         "updated_at": {
             "required": false,
-            "type": "datetime"
+            "type": "datetime",
+            "args": {
+                "onupdate": "{{datetime.datetime.utcnow}}"
+            }
         },
         "address": {
             "required": false,

--- a/schemas/story.json
+++ b/schemas/story.json
@@ -18,7 +18,10 @@
         },
         "created_at": {
             "required": false,
-            "type": "datetime"
+            "type": "datetime",
+            "args": {
+                "default": "{{datetime.datetime.utcnow}}"
+            }
         },
         "updated_at": {
             "required": false,

--- a/schemas/story.json
+++ b/schemas/story.json
@@ -25,7 +25,10 @@
         },
         "updated_at": {
             "required": false,
-            "type": "datetime"
+            "type": "datetime",
+            "args": {
+                "onupdate": "{{datetime.datetime.utcnow}}"
+            }
         },
         "start_date": {
             "required": false,

--- a/schemas/story.json
+++ b/schemas/story.json
@@ -16,7 +16,11 @@
             "required": false,
             "type": "datetime"
         },
-        "creation_date": {
+        "created_at": {
+            "required": false,
+            "type": "datetime"
+        },
+        "updated_at": {
             "required": false,
             "type": "datetime"
         },

--- a/schemas/user.json
+++ b/schemas/user.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-03/schema",
     "auth_fields": ["id", "username", "first_name", "last_name", "stories"],
     "public_fields": ["username"],
-    "nested_relationships": ["profile", "stories"],
+    "nested_relationships": ["profile"],
     "auth_model": true,
     "properties": {
         "id": {

--- a/schemas/user.json
+++ b/schemas/user.json
@@ -4,12 +4,20 @@
     "$schema": "http://json-schema.org/draft-03/schema",
     "auth_fields": ["id", "username", "first_name", "last_name", "stories"],
     "public_fields": ["username"],
-    "nested_relationships": ["profile"],
+    "nested_relationships": ["profile", "stories"],
     "auth_model": true,
     "properties": {
         "id": {
             "required": false,
             "type": "id_field"
+        },
+        "created_at": {
+            "required": false,
+            "type": "datetime"
+        },
+        "updated_at": {
+            "required": false,
+            "type": "datetime"
         },
         "profile": {
             "required": false,

--- a/schemas/user.json
+++ b/schemas/user.json
@@ -13,7 +13,10 @@
         },
         "created_at": {
             "required": false,
-            "type": "datetime"
+            "type": "datetime",
+            "args": {
+                "default": "{{datetime.datetime.utcnow}}"
+            }
         },
         "updated_at": {
             "required": false,

--- a/schemas/user.json
+++ b/schemas/user.json
@@ -20,7 +20,10 @@
         },
         "updated_at": {
             "required": false,
-            "type": "datetime"
+            "type": "datetime",
+            "args": {
+                "onupdate": "{{datetime.datetime.utcnow}}"
+            }
         },
         "profile": {
             "required": false,


### PR DESCRIPTION
- Rename Story.creation_date to created_at
- Add created_at and updated_at fields to all the models definitions
- Use default callables in new fields
- Change /users/id/profile PUT route to PATCH, as singular route updates are handled by PATCH
