### PR TITLE
Config mountpoint: change /api/ to /v1/ to match RAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,6 @@ docs/_build/
 target/
 
 local.ini
+test.ini
 mock/
 mock.sh

--- a/local.ini.template
+++ b/local.ini.template
@@ -43,9 +43,13 @@ cors.allow_credentials = true
 
 request_timing.enable = true
 
+version = v1
+
 [composite:main]
 use = egg:Paste#urlmap
-/api/ = ramses_example
+
+# needs to match path of baseUri in the RAML:
+/v1/ = ramses_example
 
 [server:main]
 use = egg:waitress#main


### PR DESCRIPTION
Updating the local.ini.template to mount the app at `/v1/` instead of `/api/` (to match the RAML).

Goes with https://github.com/brandicted/ramses/pull/83
